### PR TITLE
Fix release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,10 +43,10 @@ jobs:
           go build && mv chkbundle "chkbundle-${GOOS}-${GOARCH}"
           sha1sum chkbundle-* > chkbundle.sum
 
-      - name: Publish artifact
+      - name: Publish files to release
         if: github.event_name == 'release'
-        uses: actions/upload-artifact@v4
-        with:
-          path: |
-            chkbundle-*
-            chkbundle.sum
+        env:
+          GITHUB_TOKEN: ${{ github.TOKEN }}
+        run: |
+          gh release upload ${{github.event.release.tag_name}} chkbundle-*
+          gh release upload ${{github.event.release.tag_name}} chkbundle.sum


### PR DESCRIPTION
I misunderstood the action....it was for publishing "artifacts" _as part of the GHA workflow run_, not for publishing "assets" to the release itself.  This should work as we need it to.